### PR TITLE
Fix double timer

### DIFF
--- a/Modules/Timer.lua
+++ b/Modules/Timer.lua
@@ -99,6 +99,9 @@ function Timer:SetTimer(frame, duration, start, callback)
 	cooldown:SetSwipeColor(0, 0, 0)
 	cooldown:SetDrawEdge(false)
 	cooldown:SetDrawBling(false)
+	-- Hide Blizzard countdown numbers, we are using either our own timer or OmniCC
+	-- Without this we would see double timers
+	cooldown:SetHideCountdownNumbers(true)
 	--cooldown.currentCooldownType = COOLDOWN_TYPE_NORMAL
 
 	if not cooldown.isDisabled then


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/29640b23-d53c-4c15-9ab3-3ee41f12b504)

I don't think we are using the Blizzard default timers, either Gladius timer (with decimal precision when under 5s, and changes color), or OmniCC timers.
Currently we're seeing double timers on everything, see the screenshot above.
I think we need to suppress the Blizzard timer by calling SetHideCountdownNumbers